### PR TITLE
add setup.py file to specify deps as well as be able to run webapp anywhere

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,27 @@
+from setuptools import setup
+
+setup(
+    name='govstat',
+    version='0.0.1',
+    author='stevesdawg',
+    long_description='',
+    description='',
+    zip_safe=False,
+    packages=['app'],
+    install_requires=[
+        "flask",
+        "flask_migrate",
+        "flask_sqlalchemy",
+        "flask_wtf",
+        "numpy",
+        "pandas",
+        "pymysql",
+        "requests",
+        "xlrd",
+    ],
+    entry_points={
+        'console_scripts': [
+            'webapp = app',
+        ],
+    },
+)


### PR DESCRIPTION
Adding a `setup.py` file essentially makes this a python package and the `app/` dir can be imported anywhere, i.e. the webapp can be run anywhere.

It also allows us to track the deps need for govstat.

Try it out with a `pip install -e .`!