### PR TITLE
Fix python indentation

### DIFF
--- a/app/Bills.py
+++ b/app/Bills.py
@@ -37,8 +37,8 @@ class Bills:
                 intro_date = jsondata['introduced_at']
                 intro_date = datetime.strptime(intro_date, '%Y-%m-%d').date()
 
-		# data variable reassigned FROM json TO XML tree
-		xmldata = ET.parse(os.path.join(type_path, dir_name, XML_FILE)).getroot()
+                # data variable reassigned FROM json TO XML tree
+                xmldata = ET.parse(os.path.join(type_path, dir_name, XML_FILE)).getroot()
 
                 if last_mod_flag:
                     # check from one of the two last-modified files
@@ -125,10 +125,10 @@ class Bills:
         intro_date = jsondata['introduced_at']
         intro_date = datetime.strptime(intro_date, '%Y-%m-%d').date()
 
-	bill_q = Bill.query.filter(Bill.bill_type == bill_type) \
-	    .filter(Bill.bill_num == num) \
-	    .filter(Bill.congress == cong)
-	bills = bill_q.all()
+        bill_q = Bill.query.filter(Bill.bill_type == bill_type) \
+            .filter(Bill.bill_num == num) \
+            .filter(Bill.congress == cong)
+        bills = bill_q.all()
 
         if len(bills) > 0:
             # if the bill has been instantiated,


### PR DESCRIPTION
also add dep for `config`

```
  File "/home/acxz/vcs/git/github/stevesdawg/govstat/govstat.py", line 1, in <module>
    from app import app
  File "/home/acxz/vcs/git/github/stevesdawg/govstat/app/__init__.py", line 2, in <module>
    from config import Config
ModuleNotFoundError: No module named 'config'
```