### PR TITLE
New config logic allowing us to move away from submodules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,5 +61,5 @@ docs/_build/
 
 # db stuff
 migrations/
-app/cfg/
+app/cfg/config.json
 hist_fy21/

--- a/.gitignore
+++ b/.gitignore
@@ -61,5 +61,5 @@ docs/_build/
 
 # db stuff
 migrations/
-app/config.py
+app/cfg/
 hist_fy21/

--- a/app/Bills.py
+++ b/app/Bills.py
@@ -4,11 +4,11 @@ from datetime import datetime
 import xml.etree.cElementTree as ET
 from sqlalchemy import func
 
+import app
 from app import db
 from app.models import Vote, Bill, BillType, Representative, LegislativeSubjects, BillStatus
 
-CWD = os.path.dirname(os.path.abspath('__file__'))
-BILLS_PATH = os.path.join(CWD, '..', '..', 'congress', 'data', '116', 'bills')
+BILLS_PATH = os.path.join(app.CONGRESS_PATH, 'data', '116', 'bills')
 XML_FILE = 'fdsys_billstatus.xml'
 JSON_FILE = 'data.json'
 LAST_MOD_FILE1 = 'data-fromfdsys-lastmod.txt'

--- a/app/Budget.py
+++ b/app/Budget.py
@@ -2,12 +2,12 @@ import os
 import pandas as pd
 import numpy as np
 
+import app
 from app import db
 from app.models import DeficitSurplus, ReceiptBreakdown, OutlayBreakdown
 
 # globals
-CWD = os.path.dirname(os.path.abspath('__file__'))
-EXCEL_DIR = os.path.join(CWD, '..', 'data', 'hist_fy21')
+EXCEL_DIR = os.path.join(app.CONGRESS_PATH, 'data', 'hist_fy21')
 BUDGET_1 = 'hist01z1.xlsx'
 BUDGET_2 = 'hist02z1.xlsx'
 BUDGET_3 = 'hist03z1.xlsx'

--- a/app/Votes.py
+++ b/app/Votes.py
@@ -2,11 +2,11 @@ import os
 import json
 from datetime import datetime
 
+import app
 from app import db
 from app.models import Vote, Bill, BillType, Representative
 
-CWD = os.path.dirname(os.path.abspath('__file__'))
-VOTES_PATH = os.path.join(CWD, '..', '..', 'congress', 'data', '116', 'votes', '2020')
+VOTES_PATH = os.path.join(app.CONGRESS_PATH, 'data', '116', 'votes', '2020')
 JSON_NAME = 'data.json'
 
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -12,5 +12,11 @@ if not success:
     raise RuntimeError("no config.json file in app/cfg/ directory")
 db = SQLAlchemy(app)
 migrate = Migrate(app, db, compare_type=True)
+CONGRESS_PATH = app.config.get("CONGRESS_PATH")
+if CONGRESS_PATH is None:
+    raise RuntimeError("CONGRESS_PATH not set in cfg/config.json")
+GOVSTAT_PATH = app.config.get("GOVSTAT_PATH")
+if GOVSTAT_PATH is None:
+    raise RuntimeError("GOVSTAT_PATH not set in cfg/config.json")
 
 from app import routes, models

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,11 +1,16 @@
 from flask import Flask
-from config import Config
 from flask_sqlalchemy import SQLAlchemy
 from flask_migrate import Migrate
 
+import config
+
+
 app = Flask(__name__)
-app.config.from_object(Config)
+app.config.from_object(config.DefaultConfig)
+success = app.config.from_json("cfg/config.json", silent=True)
+if not success:
+    raise RuntimeError("no config.json file in app/cfg/ directory")
 db = SQLAlchemy(app)
 migrate = Migrate(app, db, compare_type=True)
 
-from app import routes, models, Votes, Budget
+from app import routes, models

--- a/app/cfg/README.md
+++ b/app/cfg/README.md
@@ -1,0 +1,8 @@
+Add a `config.json` file to this directory.
+
+Required properties that need to be set:
+
+- `SQLALCHEMY_DATABASE_URI`
+- `SECRET_KEY`
+- `CONGRESS_PATH`
+- `GOVSTAT_PATH`

--- a/app/cfg/config.sample.json
+++ b/app/cfg/config.sample.json
@@ -1,0 +1,6 @@
+{
+    "SQLALCHEMY_DATABASE_URI": "",
+    "SECRET_KEY": "",
+    "CONGRESS_PATH": "",
+    "GOVSTAT_PATH": ""
+}

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,7 @@
+import os
+
+basedir = os.path.abspath(os.path.dirname(__file__))
+
+class DefaultConfig(object):
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
+    JSONIFY_PRETTYPRINT_REGULAR = True

--- a/app/routes.py
+++ b/app/routes.py
@@ -3,14 +3,15 @@ import json
 import requests
 import datetime
 from flask import render_template, jsonify, request
+
+from app import CONGRESS_PATH
 from app.Votes import Votes
 from app.Bills import Bills
-from app import Budget
+import app.Budget as Budget
 from app import app
 
 # globals
-CWD = os.path.dirname(os.path.abspath('__file__'))
-BILLS_PATH = os.path.join(CWD, '..', '..', 'congress', 'data', '116', 'bills')
+BILLS_PATH = os.path.join(CONGRESS_PATH, 'data', '116', 'bills')
 JSON_NAME = 'data.json'
 
 # BILLS SCRAPER


### PR DESCRIPTION
- Default config object.
- Looks in app/cfg for a config.json file for app specific configuration and credentials.
- Uses path to congress repo in config.json file to read data files, instead of relying on absolute or relative paths.
- Descriptive error messages when certain config options are not found.