### PR TITLE
Port to Python 3.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # govstat
 
 Source code for [GovStat.us](https://govstat.us) website.
-Webserver is implemented using Flask on Python 2.7.
+
+Webserver is implemented using Flask on Python 3.10.
+
+Install locally using `pip install .`
 
 ### Dependencies required: ###
 - gunicorn


### PR DESCRIPTION
No code changes. Repo (webserver and database loaders) was tested against python 3.10 and works normally.

Closes #10.