### PR TITLE
add dummy values to help users understand the cfg format

### DIFF
--- a/app/cfg/config.sample.json
+++ b/app/cfg/config.sample.json
@@ -1,6 +1,6 @@
 {
-    "SQLALCHEMY_DATABASE_URI": "",
+    "SQLALCHEMY_DATABASE_URI": "mariadb+mariadbconnector://user:password@localhost:5000/mysql",
     "SECRET_KEY": "",
-    "CONGRESS_PATH": "",
-    "GOVSTAT_PATH": ""
+    "CONGRESS_PATH": "/home/user/github/unitedstates/congress",
+    "GOVSTAT_PATH": "/home/user/github/stevesdawg/govstat"
 }

--- a/app/cfg/config.sample.json
+++ b/app/cfg/config.sample.json
@@ -1,5 +1,5 @@
 {
-    "SQLALCHEMY_DATABASE_URI": "mariadb+mariadbconnector://user:password@localhost:5000/mysql",
+    "SQLALCHEMY_DATABASE_URI": "mariadb+mariadbconnector://user:password@localhost:5000/table_name",
     "SECRET_KEY": "",
     "CONGRESS_PATH": "/home/user/github/unitedstates/congress",
     "GOVSTAT_PATH": "/home/user/github/stevesdawg/govstat"


### PR DESCRIPTION
Having some defaults (even if they are dummy values) can help users fill in the corresponding fields.